### PR TITLE
Refactor: Switch to EditorWindow.focusedWindow to resolve (#77)

### DIFF
--- a/Assets/MasyoLab/FavoritesAsset/CHANGELOG.md
+++ b/Assets/MasyoLab/FavoritesAsset/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.5.6] - 2026-03-12
+## Changes
+- Refactor: Switch to EditorWindow.focusedWindow to resolve (#77)
+
 ## [1.5.5] - 2026-02-19
 ## Changes
 - fix(asmdef): set Examples asmdef to Editor platform (Assets/MasyoLab/FavoritesAsset/Examples/MasyoLab-FavoritesAssetExample.asmdef)

--- a/Assets/MasyoLab/FavoritesAsset/Editor/Core/Const.cs
+++ b/Assets/MasyoLab/FavoritesAsset/Editor/Core/Const.cs
@@ -15,7 +15,7 @@ namespace MasyoLab.Editor.FavoritesAsset
     struct CONST
     {
         public const string DEVELOPER = "MasyoLab";
-        public const string VERSION = "ver 1.5.5";
+        public const string VERSION = "ver 1.5.6";
         public const string EDITOR_NAME = "Favorites Asset";
         public const string EDITOR_WINDOW_NAME = "Favorites Asset Window";
         public const string MENU_ITEM = "Tools/" + EDITOR_WINDOW_NAME;

--- a/Assets/MasyoLab/FavoritesAsset/Editor/Window/FavoritesWindow.cs
+++ b/Assets/MasyoLab/FavoritesAsset/Editor/Window/FavoritesWindow.cs
@@ -246,47 +246,6 @@ namespace MasyoLab.Editor.FavoritesAsset
         }
 
         /// <summary>
-        /// マウスが特定の EditorWindow 上にあるか
-        /// </summary>
-        /// <param name="window"></param>
-        /// <returns></returns>
-        private static bool IsMouseOverWindow(EditorWindow window)
-        {
-            if (window == null)
-            {
-                return false;
-            }
-
-            // 標準判定（速い）
-            if (EditorWindow.mouseOverWindow == window)
-            {
-                return true;
-            }
-
-#if UNITY_6000_3_OR_NEWER
-            // フォールバック：イベントのマウス座標をスクリーン座標に変換してウィンドウ矩形と比較
-            // Unity 6000.3 LTS で発生する回帰バグ回避:
-            // ドラッグ操作中に `EditorWindow.mouseOverWindow` が更新されない問題が発生。
-            // そのためドラッグ中はイベントの mousePosition をスクリーン座標に変換し、
-            // 全ての EditorWindow の矩形と比較してマウス下のウィンドウを判定するフォールバック実装を使用します。
-            // This is a workaround for a regression in Unity 6000.3 LTS where
-            // `EditorWindow.mouseOverWindow` is not updated during drag operations.
-            // Use Event.current.mousePosition -> GUIUtility.GUIToScreenPoint and compare
-            // against window.position as a fallback.
-            var ev = Event.current;
-            if (ev == null)
-            {
-                return false;
-            }
-
-            var screenPoint = GUIUtility.GUIToScreenPoint(ev.mousePosition);
-            return window.position.Contains(screenPoint);
-#else
-            return false;
-#endif
-        }
-
-        /// <summary>
         /// ドラッグ&ドロップでオブジェクトを取得
         /// </summary>
         /// <param name="targetList"></param>
@@ -323,10 +282,6 @@ namespace MasyoLab.Editor.FavoritesAsset
         private static UnityEngine.Object[] GetObjects(EditorWindow window, Rect? rect = null)
         {
             var ev = Event.current;
-            if (ev == null)
-            {
-                return null;
-            }
 
             // エリアが指定されていれば範囲内か確認
             if (rect.HasValue && !rect.Value.Contains(ev.mousePosition))
@@ -341,12 +296,7 @@ namespace MasyoLab.Editor.FavoritesAsset
             }
 
             var paths = DragAndDrop.paths;
-            if (paths == null)
-            {
-                return null;
-            }
-
-            if (!IsMouseOverWindow(window) || paths.Length <= 0)
+            if (EditorWindow.focusedWindow != window || paths.Length <= 0)
             {
                 return null;
             }

--- a/Assets/MasyoLab/FavoritesAsset/package.json
+++ b/Assets/MasyoLab/FavoritesAsset/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.masyo-lab.favorites-asset",
   "displayName": "Favorites Asset Window",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "unity": "2019.4",
   "description": "This function allows you to bookmark (register as a favorite) resources.\nMIT License\nCopyright (c) 2021 MasyoLab",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.5.6] - 2026-03-12
+## Changes
+- Refactor: Switch to EditorWindow.focusedWindow to resolve (#77)
+
 ## [1.5.5] - 2026-02-19
 ## Changes
 - fix(asmdef): set Examples asmdef to Editor platform (Assets/MasyoLab/FavoritesAsset/Examples/MasyoLab-FavoritesAssetExample.asmdef)


### PR DESCRIPTION
- Root Cause & Upstream Fix: The bug addressed in (#77) was originally caused by a Unity Editor bug ([Unity Issue Tracker(Issue ID UUM-133941)](https://issuetracker.unity3d.com/issues/pick-style-only-responds-to-elements-on-the-first-hovered-window-when-using-the-imgui-debugger)). This upstream issue has been fixed in Unity versions 6000.3.11f1, 6000.4.0b11, and 6000.5.0a8.
- Behavior Verification: I tested the fix, but the core behavior of EditorWindow.mouseOverWindow hasn't really changed. (The phenomenon where the return value rarely fluctuates no longer occurs, but... that's not what I needed!).
- Resolution: I have given up on using EditorWindow.mouseOverWindow and updated the implementation to use EditorWindow.focusedWindow instead.